### PR TITLE
assumes vdb in $PATH. doesnt care about user config.

### DIFF
--- a/R/dbgap.decrypt.R
+++ b/R/dbgap.decrypt.R
@@ -8,42 +8,20 @@
 #' @author Gregoire Versmee, Laura Versmee
 #' @export
 
-dbgap.decrypt <- function(file)  {
+dbgap.decrypt <- function(file, key){
+    ## file paths cleaning and quoting
+    file = shQuote( normalizePath( file ))
+    key  = shQuote( normalizePath( key ))
 
-message("Where is your key?")
-key <- file.choose()
+    ## get the R temp dir (for the decryption tool)
+    config.dir = tempdir()
+    
+    ## import the key and tell vdb what config dir we want to use
+    system2("vdb-config",c("--import", key, config.dir))
 
-## escape regex symbols
-file <- gsub(" ", "\\\\ ", file)
-key <- gsub(" ", "\\\\ ", key)
+    ## this is required for the decryption program to run without error
+    setwd(config.dir)
 
-wd <- getwd()
-
-# DL and untar sratoolkit for mac
-download.file("ftp-trace.ncbi.nlm.nih.gov/sra/sdk/2.8.2-1/sratoolkit.2.8.2-1-mac64.tar.gz", "./sratoolkit.2.8.2-1-mac64.tar.gz")
-untar("./sratoolkit.2.8.2-1-mac64.tar.gz")
-file.remove("./sratoolkit.2.8.2-1-mac64.tar.gz")
-
-#Reset the sra settings
-if (file.exists("~/.ncbi/user-settings.mkfg"))  file.remove("~/.ncbi/user-settings.mkfg")
-
-# import the key
-system(paste("./sratoolkit.2.8.2-1-mac64/bin/vdb-config --import", key))
-Sys.sleep(1)
-
-#set the wd to the repository
-p <- read.table("~/.ncbi/user-settings.mkfg")
-repo <- as.character(p[which(grepl("root", p[ ,1])), 3])
-setwd(repo)
-
-# decrypt the files
-g <- system(paste0(wd, "/sratoolkit.2.8.2-1-mac64/bin/vdb-decrypt ", file))
-
-#clean up your mess!
-setwd(wd)
-file.remove(repo)
-sra <- list.files(pattern = "sratoolkit*")
-system(paste0("rm -r ./", sra))
+    ## decrypt the files
+    g <- system2("vdb-decrypt", file)
 }
-
-


### PR DESCRIPTION
Since we're going to use the CentOS version in the future, and if we want other users to be able to use the code, we cannot make assumption about the version of the software. So we can't download it for them.
We could add a way for the user to specify the path to the binaries "vdb-*" .

The path to the key file is now a parameter to the decrypt function.
Inside the function the paths are normalized (so that paths like "~/..." are resolved correctly) and quoted qith shQuote (it adds quotes around the string so that we don't need to bother with escaping the spaces in it)

I replaced system by system2, the argument handling is better

and that's about it, basically I just moved things around, but the core of the function you wrote stays the same!